### PR TITLE
Allow multiple remotes to trigger events in HomeAssitant

### DIFF
--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,9 +4,6 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
-  if (wizmote.sequence <= this->last_sequence_)
-    return;
-
   this->last_sequence_ = wizmote.sequence;
   this->on_button_->trigger(wizmote);
 }

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,6 +4,9 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
+  if (wizmote.sequence <= this->last_sequence_)
+    return;
+  
   this->last_sequence_ = wizmote.sequence;
   this->on_button_->trigger(wizmote);
 }

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,16 +4,28 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
-  if (wizmote.sequence <= this->last_sequence_ && wizmote.bssid == this->last_bssid_)
+
+  bool isequal = true;
+  
+  for(int i=0; i < 6; i++) {
+
+    if(this->last_bssid_[i] != wizmote.bssid[i]){
+      isequal = false;
+      break;
+    }
+
+  }
+
+  if (isequal && wizmote.sequence <= this->last_sequence_)
     return;
   
-  this->last_sequence_ = wizmote.sequence;
+  this->last_sequence_ = this->last_bssid_[i];
 
   for(i=0;i<6;i++)
   {
     this->last_bssid_[i]=wizmote.bssid[i];
   }
-  
+
   this->on_button_->trigger(wizmote);
 }
 }  // namespace wizmote

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -21,7 +21,7 @@ void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   
   this->last_sequence_ = this->last_bssid_[i];
 
-  for(i=0;i<6;i++)
+  for(int i=0;i<6;i++)
   {
     this->last_bssid_[i]=wizmote.bssid[i];
   }

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -19,7 +19,7 @@ void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   if (isequal && wizmote.sequence <= this->last_sequence_)
     return;
   
-  this->last_sequence_ = this->last_bssid_[i];
+  this->last_sequence_ = wizmote.sequence;
 
   for(int i=0;i<6;i++)
   {

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,10 +4,16 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
-  if (wizmote.sequence <= this->last_sequence_)
+  if (wizmote.sequence <= this->last_sequence_ && wizmote.bssid == this->last_bssid_)
     return;
   
   this->last_sequence_ = wizmote.sequence;
+
+  for(i=0;i<6;i++)
+  {
+    this->last_bssid_[i]=wizmote.bssid[i];
+  }
+  
   this->on_button_->trigger(wizmote);
 }
 }  // namespace wizmote

--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -43,6 +43,7 @@ class WizMoteListener : public esp_now::ESPNowListener {
 
  protected:
   uint32_t last_sequence_ = 0;
+  uint8_t last_bssid_[6] = {0,0,0,0,0,0}
   Trigger<WizMotePacket> *on_button_ = new Trigger<WizMotePacket>();
 };
 

--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -43,7 +43,7 @@ class WizMoteListener : public esp_now::ESPNowListener {
 
  protected:
   uint32_t last_sequence_ = 0;
-  uint8_t last_bssid_[6] = {0,0,0,0,0,0}
+  uint8_t last_bssid_[6] = {0,0,0,0,0,0};
   Trigger<WizMotePacket> *on_button_ = new Trigger<WizMotePacket>();
 };
 


### PR DESCRIPTION
This change compares the bssid (which is different per remote) in addition to last sequence. It means having two or more remotes would still trigger one event to Home Assistant (feel free to change my code, just learning C++)