### PR TITLE
Improved support of multiple remotes

### DIFF
--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,7 +4,7 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
-  if (wizmote.sequence <= this->last_sequence_)
+  if (wizmote.sequence == this->last_sequence_)
     return;
 
   this->last_sequence_ = wizmote.sequence;

--- a/components/wizmote/wizmote.cpp
+++ b/components/wizmote/wizmote.cpp
@@ -4,11 +4,54 @@ namespace esphome {
 namespace wizmote {
 void WizMoteListener::on_esp_now_message(esp_now::ESPNowPacket packet) {
   WizMotePacket wizmote = WizMotePacket::build(packet);
-  if (wizmote.sequence == this->last_sequence_)
+  if (update_wizmote_history(&wizmote))
     return;
 
-  this->last_sequence_ = wizmote.sequence;
   this->on_button_->trigger(wizmote);
 }
+
+bool WizMoteListener::update_wizmote_history(WizMotePacket *packet)
+{
+  uint8_t index = 0;
+  if (find_bssid_index(packet, &index))
+  {
+    if (this->history[index].sequence == packet->sequence)
+      return true;
+    
+    // We had a matching MAC, but not a matching sequence, 
+    this->history[index].sequence = packet->sequence;
+  }
+  
+  for (uint8_t i = (WIZMOTEHISTORYSIZE - 1); i > 0; i--)
+    memcpy(&(this->history[i]), &(this->history[i-1]), sizeof(WizMoteHistory));
+  this->history[0].sequence = packet->sequence;
+  memcpy(this->history[0].bssid, packet->bssid, 6);
+  
+  return false;
+}
+
+bool WizMoteListener::find_bssid_index(WizMotePacket *packet, uint8_t *index)
+{
+  for (uint8_t i = 0; i < WIZMOTEHISTORYSIZE; i++)
+  {
+    if (is_bssid_equal(packet, &(this->history[i])))
+    {
+      *index = i;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool WizMoteListener::is_bssid_equal(WizMotePacket *packet, WizMoteHistory *history)
+{
+  for (uint8_t i = 0; i < 6; i++)
+  {
+    if (packet->bssid[i] != history->bssid[i])
+      return false;
+  }
+  return true;
+}
+  
 }  // namespace wizmote
 }  // namespace esphome

--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -9,6 +9,8 @@
 namespace esphome {
 namespace wizmote {
 
+static const uint8_t WIZMOTEHISTORYSIZE = 20;
+
 typedef struct WizMotePacket {
   uint8_t bssid[6];
 
@@ -34,6 +36,11 @@ typedef struct WizMotePacket {
     return packet;
   }
 } WizMotePacket;
+  
+typedef struct WizMoteHistory {
+  uint8_t bssid[6];
+  uint32_t sequence;
+} WizMoteHistory;
 
 class WizMoteListener : public esp_now::ESPNowListener {
  public:
@@ -42,9 +49,13 @@ class WizMoteListener : public esp_now::ESPNowListener {
   Trigger<WizMotePacket> *get_on_button_trigger() { return this->on_button_; }
 
  protected:
-  uint32_t last_sequence_ = 0;
+  bool update_wizmote_history(WizMotePacket *packet);
+  bool find_bssid_index(WizMotePacket *packet, uint8_t *index);
+  bool is_bssid_equal(WizMotePacket *packet, WizMoteHistory *history);
+  WizMoteHistory history[WIZMOTEHISTORYSIZE] = {0,};
   Trigger<WizMotePacket> *on_button_ = new Trigger<WizMotePacket>();
 };
+  
 
 }  // namespace wizmote
 }  // namespace esphome

--- a/wizmote-esphome-blueprint.yml
+++ b/wizmote-esphome-blueprint.yml
@@ -85,6 +85,8 @@ action:
         - wait_for_trigger:
             - platform: event
               event_type: esphome.wizmote_action
+              event_data:
+                mac: !input "remote"
           continue_on_timeout: false
           timeout: 00:00:05
         - choose:


### PR DESCRIPTION
The official version breaks when multiple remotes are used. This patch is not perfect, but works with multiple remotes with the following limitation: Filtering out duplicate messages does not work when multiple remotes are pressed at the same time, causing what appears to be multiple presses. This occurs only when multiple remotes have a button pressed at the same time.

Updates were made to the .cpp file to check for duplicate espnow messages.

Updates were also made to the blueprint yml file to add verification of remote mac address for all triggers, not just the first.