### PR TITLE
Improve WizPacket decoding

### DIFF
--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -16,15 +16,11 @@ typedef struct __attribute__((__packed__)) WizMotePacket {
 
   uint8_t program;      // 0x91 for ON button, 0x81 for all others
   uint32_t sequence;    // Incremental sequence number 32 bit unsigned integer LE
-  uint8_t byte5 = 32;   // Unknown
+  uint8_t dType1 = 32;  // Data type: button (32)
   uint8_t button;       // Identifies which button is being pressed
-  uint8_t byte8 = 1;    // Unknown, but always 0x01
-  uint8_t byte9 = 100;  // Unnkown, but always 0x64
-
-  uint8_t byte10;  // Unknown, maybe checksum
-  uint8_t byte11;  // Unknown, maybe checksum
-  uint8_t byte12;  // Unknown, maybe checksum
-  uint8_t byte13;  // Unknown, maybe checksum
+  uint8_t dType2 = 1;   // Data type: batteryLevel (1)
+  uint8_t batteryLevel; // WiZMote batteryLevel out of 100
+  uint8_t mac[4];       // CCM MAC (Message Authentication Code)
 
   static inline WizMotePacket build(esp_now::ESPNowPacket espnow_packet) {
     WizMotePacket packet;

--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -14,7 +14,14 @@ static const uint8_t WIZMOTEHISTORYSIZE = 20;
 typedef struct __attribute__((__packed__)) WizMotePacket {
   uint8_t bssid[6];
 
-  uint8_t program;      // 0x91 for ON button, 0x81 for all others
+  union {
+    uint8_t program;    // 0x91 for ON button, 0x81 for all others
+    struct __attribute__((__packed__)) {
+      unsigned :4;
+      unsigned pairing:1;
+      unsigned :3;
+    };
+  };
   uint32_t sequence;    // Incremental sequence number 32 bit unsigned integer LE
   uint8_t dType1 = 32;  // Data type: button (32)
   uint8_t button;       // Identifies which button is being pressed

--- a/components/wizmote/wizmote.h
+++ b/components/wizmote/wizmote.h
@@ -11,11 +11,11 @@ namespace wizmote {
 
 static const uint8_t WIZMOTEHISTORYSIZE = 20;
 
-typedef struct WizMotePacket {
+typedef struct __attribute__((__packed__)) WizMotePacket {
   uint8_t bssid[6];
 
   uint8_t program;      // 0x91 for ON button, 0x81 for all others
-  uint8_t seq[4];       // Incremetal sequence number 32 bit unsigned integer LSB first
+  uint32_t sequence;    // Incremental sequence number 32 bit unsigned integer LE
   uint8_t byte5 = 32;   // Unknown
   uint8_t button;       // Identifies which button is being pressed
   uint8_t byte8 = 1;    // Unknown, but always 0x01
@@ -26,13 +26,10 @@ typedef struct WizMotePacket {
   uint8_t byte12;  // Unknown, maybe checksum
   uint8_t byte13;  // Unknown, maybe checksum
 
-  uint32_t sequence;
-
   static inline WizMotePacket build(esp_now::ESPNowPacket espnow_packet) {
     WizMotePacket packet;
     memcpy(packet.bssid, espnow_packet.get_bssid().data(), 6);
-    memcpy(&(packet.program), espnow_packet.get_data().data(), espnow_packet.get_data().size());
-    packet.sequence = encode_uint32(packet.seq[3], packet.seq[2], packet.seq[1], packet.seq[0]);
+    memcpy(&packet.program, espnow_packet.get_data().data(), espnow_packet.get_data().size());
     return packet;
   }
 } WizMotePacket;


### PR DESCRIPTION
Since the platform is already LE, I removed the step of manually shuffling bytes to resolve sequence number.

I also fleshed out the missing fields of the WizPacket struct and exposed the `pairing` bit via bitfield union.