### PR TITLE
Track ESP-NOW API change for ESP32

### DIFF
--- a/components/esp_now/esp_now_component.cpp
+++ b/components/esp_now/esp_now_component.cpp
@@ -86,10 +86,11 @@ void ESPNowComponent::dump_config() { ESP_LOGCONFIG(TAG, "esp_now:"); }
 
 #ifdef USE_ESP8266
 void ESPNowComponent::on_data_received(uint8_t *bssid, uint8_t *data, uint8_t len) {
+  auto packet = make_unique<ESPNowPacket>(bssid, data, len);
 #elif defined(USE_ESP32)
 void ESPNowComponent::on_data_received(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int len) {
-#endif
   auto packet = make_unique<ESPNowPacket>(esp_now_info->src_addr, data, len);
+#endif
   global_esp_now->receive_queue_.push(std::move(packet));
 }
 

--- a/components/esp_now/esp_now_component.cpp
+++ b/components/esp_now/esp_now_component.cpp
@@ -87,9 +87,9 @@ void ESPNowComponent::dump_config() { ESP_LOGCONFIG(TAG, "esp_now:"); }
 #ifdef USE_ESP8266
 void ESPNowComponent::on_data_received(uint8_t *bssid, uint8_t *data, uint8_t len) {
 #elif defined(USE_ESP32)
-void ESPNowComponent::on_data_received(const uint8_t *bssid, const uint8_t *data, int len) {
+void ESPNowComponent::on_data_received(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int len) {
 #endif
-  auto packet = make_unique<ESPNowPacket>(bssid, data, len);
+  auto packet = make_unique<ESPNowPacket>(esp_now_info->src_addr, data, len);
   global_esp_now->receive_queue_.push(std::move(packet));
 }
 

--- a/components/esp_now/esp_now_component.h
+++ b/components/esp_now/esp_now_component.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#if defined(USE_ESP32)
+#include <esp_now.h>
+#endif
+
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -44,7 +48,7 @@ class ESPNowComponent : public Component {
 #ifdef USE_ESP8266
   static void on_data_received(uint8_t *bssid, uint8_t *data, uint8_t len);
 #elif defined(USE_ESP32)
-  static void on_data_received(const uint8_t *bssid, const uint8_t *data, int len);
+  static void on_data_received(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int len);
 #endif
 
   Trigger<ESPNowPacket> *get_on_packet_trigger() { return this->on_packet_; }


### PR DESCRIPTION
Fixes #31 [[ESPHome 2024.12.x] ESPNow won't compile with version 2024.12.x of ESPHome](https://github.com/jesserockz/wizmote-esphome/issues/31#top) for ESP32 devices (I don't have any ESP8266 devices, so I can't test any changes for those).